### PR TITLE
Adopt cannon flake "schema"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,14 +29,14 @@
       system: (pkgs.${system}.callPackage ./lib {})
     );
 
-    packages = genSystems (system: rec {
+    packages = genSystems (system: {
       spicetify = pkgs.${system}.callPackage ./pkgs {};
-      default = spicetify;
+      default = self.packages.${system}.spicetify;
     });
 
-    homeManagerModules = rec {
+    homeManagerModules = {
       spicetify = import ./module.nix;
-      default = spicetify;
+      default = self.homeManagerModules.spicetify;
     };
 
     pkgSets = genSystems (system: (

--- a/flake.nix
+++ b/flake.nix
@@ -20,8 +20,6 @@
     # legacy reasons...
     defaultSystem = "x86_64-linux";
   in {
-    homeManagerModule = import ./module.nix;
-
     # legacy stuff thats just for x86_64 linux
     pkgs = pkgs.${defaultSystem}.callPackage ./pkgs {};
     lib = pkgs.${defaultSystem}.callPackage ./lib {};
@@ -30,8 +28,15 @@
     libs = genSystems (
       system: (pkgs.${system}.callPackage ./lib {})
     );
-    pkgSets = genSystems (
-      system: (pkgs.${system}.callPackage ./pkgs {})
-    );
+
+    packages = genSystems (system: rec {
+      spicetify = pkgs.${system}.callPackage ./pkgs {};
+      default = spicetify;
+    });
+
+    homeManagerModules = rec {
+      spicetify = import ./module.nix;
+      default = spicetify;
+    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -38,5 +38,16 @@
       spicetify = import ./module.nix;
       default = spicetify;
     };
+
+    pkgSets = genSystems (system: (
+      nixpkgs.lib.warn
+      "deprecated, use packages.${system}.default"
+      self.packages.${system}.default
+    ));
+
+    homeManagerModule =
+      nixpkgs.lib.warn
+      "deprecated, use homeManagerModules.default"
+      self.homeManagerModules.default;
   };
 }


### PR DESCRIPTION
While there is no absolute "schema", there are accepted standards.

I once ran across a page that had all of the common practices layed out, and I wish I had saved it. But for now, the Nix Wiki is the best [resource](https://nixos.wiki/wiki/Flakes#Output_schema) I can find on the topic.

I did not remove any of the misnamed outputs, I simply added a deprecation message for those who try to use them.

Some people pipe their inputs through some functions that try to do a multitude of things (myself included) such as generate attrsets of modules and overlays, etc.

When you use non-standard names, users of your Flake must either fork it, and hope that a pull request gets accepted, or deal with it and accept that your flake is a special snow*Flake* and introduce specific code.