### PR TITLE
v1.2.1 - Add spotifywm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ in
     in
     {
       # use spotify from the nixpkgs master branch
-      spotifyPackage = unstable.spotify-unwrapped;
+      spotifyPackage = unstable.spotify;
 
       # use a custom build of spicetify
       spicetifyPackage = pkgs.spicetify-cli.overrideAttrs (oa: rec {

--- a/module.nix
+++ b/module.nix
@@ -325,7 +325,7 @@ in {
       isSpotifyWM = cfg.spotifyPackage == pkgs.spotifywm;
       spotifyToOverride =
         if isSpotifyWM
-        then pkgs.spotify
+        then builtins.trace "USING SPOTIFY WM" pkgs.spotify
         else cfg.spotifyPackage;
       overridenSpotify = spotifyToOverride.overrideAttrs (_: rec {
         postInstall = finalScript;

--- a/module.nix
+++ b/module.nix
@@ -325,7 +325,7 @@ in {
       isSpotifyWM = cfg.spotifyPackage == pkgs.spotifywm;
       spotifyToOverride =
         if isSpotifyWM
-        then builtins.trace "USING SPOTIFY WM" pkgs.spotify
+        then pkgs.spotify
         else cfg.spotifyPackage;
       overridenSpotify = spotifyToOverride.overrideAttrs (_: rec {
         postInstall = finalScript;

--- a/template/home.nix
+++ b/template/home.nix
@@ -18,7 +18,6 @@
   # list where you can specify unfree packages to allow
   nixpkgs.config.allowUnfreePredicate = pkg:
     builtins.elem (lib.getName pkg) [
-      "spotify-unwrapped"
       "spotify"
     ];
 


### PR DESCRIPTION
if ``cfg.spotifyPackage`` is spotifywm, then create the spiced spotify derivation and pass it into the spotifywm wrapper.

Also add ``dontInstall`` and ``spicedSpotify`` and ``createPackages`` options, the latter two of which are set by the module and can be used instead of installing the packages.