### PR TITLE
Add default value for colorScheme if customColorScheme is set

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -103,7 +103,7 @@ in {
     };
     colorScheme = mkOption {
       type = lib.types.nullOr lib.types.str;
-      default = null;
+      default = if cfg.customColorScheme != null then "custom" else null;
     };
     customColorScheme = mkOption {
       type = lib.types.nullOr lib.types.attrs;


### PR DESCRIPTION
A quality of live improvement if a `customColorScheme` is set, the color scheme is `custom`