### PR TITLE
Update css map and make it easier to keep up to date

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,39 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "flake-utils": {
       "locked": {
-        "lastModified": 1655043425,
-        "narHash": "sha256-A+oT+aQGhW5lXy8H0cqBLsYtgcnT5glmGOXWQDcGw6I=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "914ef51ffa88d9b386c71bdc88bffc5273c08ada",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677932085,
+        "narHash": "sha256-+AB4dYllWig8iO6vAiGGYl0NEgmMgGHpy9gzWJ3322g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
         "ref": "nixos-unstable",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -34,7 +34,24 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "spicetify-cli": "spicetify-cli"
+      }
+    },
+    "spicetify-cli": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1677851665,
+        "narHash": "sha256-C5J+OJjoiPOo/scVd48lTBJKKWial3TCkCIDBSerO+4=",
+        "owner": "spicetify",
+        "repo": "spicetify-cli",
+        "rev": "c9d8068d58d8c45f961ca42edcea47d7be904164",
+        "type": "github"
+      },
+      "original": {
+        "owner": "spicetify",
+        "repo": "spicetify-cli",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,17 +5,22 @@
     nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
 
     flake-utils.url = "github:numtide/flake-utils";
+
+    spicetify-cli = {
+      url = "github:spicetify/spicetify-cli";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
+  outputs = { self, nixpkgs, flake-utils, spicetify-cli, ... }:
     {
       homeManagerModules = {
-        spicetify = (import ./module.nix) { isNixOSModule = false; };
+        spicetify = (import ./module.nix) { isNixOSModule = false; inherit spicetify-cli; };
         default = self.homeManagerModules.spicetify;
       };
 
       nixosModules = {
-        spicetify = import ./module.nix { isNixOSModule = true; };
+        spicetify = import ./module.nix { isNixOSModule = true; inherit spicetify-cli; };
         default = self.nixosModules.spicetify;
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,70 +2,58 @@
   description = "A nix flake that provides a home-manager module to configure spicetify with.";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    ...
-  }: let
-    supportedSystems = [
-      "x86_64-linux"
-      "aarch64-linux"
-    ];
-    genSystems = nixpkgs.lib.genAttrs supportedSystems;
-    gennedPkgs = genSystems (system: import nixpkgs {inherit system;});
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    {
+      homeManagerModules = {
+        spicetify = (import ./module.nix) { isNixOSModule = false; };
+        default = self.homeManagerModules.spicetify;
+      };
 
-    # legacy reasons...
-    defaultSystem = "x86_64-linux";
-  in {
-    libs = genSystems (
-      system: (gennedPkgs.${system}.callPackage ./lib {})
-    );
+      nixosModules = {
+        spicetify = import ./module.nix { isNixOSModule = true; };
+        default = self.nixosModules.spicetify;
+      };
 
-    packages = genSystems (system: {
-      spicetify = gennedPkgs.${system}.callPackage ./pkgs {};
-      default = self.packages.${system}.spicetify;
-    });
+      # nice aliases
+      homeManagerModule = self.homeManagerModules.default;
+      nixosModule = self.nixosModules.default;
 
-    homeManagerModules = {
-      spicetify = (import ./module.nix) {isNixOSModule = false;};
-      default = self.homeManagerModules.spicetify;
-    };
-
-    nixosModules = {
-      spicetify = import ./module.nix {isNixOSModule = true;};
-      default = self.nixosModules.spicetify;
-    };
-
-    # nice aliases
-    homeManagerModule = self.homeManagerModules.default;
-    nixosModule = self.nixosModules.default;
-
-    templates.default = {
-      path = ./template;
-      description = "A basic home-manager configuration which installs spicetify with the Dribbblish theme.";
-    };
-
-    formatter = genSystems (system: gennedPkgs.${system}.alejandra);
-
-    # DEPRECATED ---------------------------------------------------------------
-
-    pkgSets = genSystems (system: (
-      nixpkgs.lib.warn
-      "spicetify-nix.pkgSets is deprecated, use spicetify-nix.packages.\${pkgs.system}.default"
-      self.packages.${system}.default
-    ));
-
+      templates.default = {
+        path = ./template;
+        description = "A basic home-manager configuration which installs spicetify with the Dribbblish theme.";
+      };
+    }
     # legacy stuff thats just for x86_64 linux
-    pkgs =
-      nixpkgs.lib.warn
-      "spicetify-nix.pkgs is deprecated, use spicetify-nix.packages.\${pkgs.system}"
-      (gennedPkgs.${defaultSystem}.callPackage ./pkgs {});
-    lib =
-      nixpkgs.lib.warn
-      "spicetify-nix.lib is deprecated, use spicetify-nix.libs.\${pkgs.system}"
-      (gennedPkgs.${defaultSystem}.callPackage ./lib {});
-  };
+    // (let legacyPkgs = import nixpkgs { system = flake-utils.lib.system.x86_64-linux; };
+    in {
+      pkgs = nixpkgs.lib.warn
+        "spicetify-nix.pkgs is deprecated, use spicetify-nix.packages.\${pkgs.system}"
+        (legacyPkgs.callPackage ./pkgs { });
+      lib = nixpkgs.lib.warn
+        "spicetify-nix.lib is deprecated, use spicetify-nix.libs.\${pkgs.system}"
+        (legacyPkgs.callPackage ./lib { });
+    }) // flake-utils.lib.eachSystem
+    (let inherit (flake-utils.lib) system; in [ system.aarch64-linux system.x86_64-linux ]) (system:
+      let pkgs = import nixpkgs { inherit system; };
+      in {
+        libs = pkgs.callPackage ./lib { };
+
+        packages = {
+          spicetify = pkgs.callPackage ./pkgs { };
+          default = self.packages.${system}.spicetify;
+        };
+
+        formatter = pkgs.alejandra;
+
+        # DEPRECATED ---------------------------------------------------------------
+
+        pkgSets = nixpkgs.lib.warn
+          "spicetify-nix.pkgSets is deprecated, use spicetify-nix.packages.\${pkgs.system}.default"
+          self.packages.${system}.default;
+      });
 }

--- a/module.nix
+++ b/module.nix
@@ -1,11 +1,11 @@
-{isNixOSModule ? false}: {
+{ isNixOSModule ? false, spicetify-cli ? null }: {
   lib,
   pkgs,
   config,
   ...
 }:
 with lib; let
-  inherit (pkgs) callPackage fetchurl;
+  inherit (pkgs) callPackage fetchFromGitHub;
   cfg = config.programs.spicetify;
   spiceLib = callPackage ./lib {};
   spiceTypes = spiceLib.types;
@@ -112,10 +112,17 @@ in {
 
     cssMap = mkOption {
       type = lib.types.path;
-      default = fetchurl {
-        url = "https://raw.githubusercontent.com/spicetify/spicetify-cli/6f473f28151c75e08e83fb280dd30fadd22d9c04/css-map.json";
-        sha256 = "1qj0hlq98hz4v318qhz6ijyrir96fj962gqz036dm4jka3bg06l7";
-      };
+      default = let
+        src = if (spicetify-cli != null) then
+          spicetify-cli
+        else
+          fetchFromGitHub {
+            owner = "spicetify";
+            repo = "spicetify-cli";
+            rev = "c9d8068d58d8c45f961ca42edcea47d7be904164";
+            sha256 = "sha256-C5J+OJjoiPOo/scVd48lTBJKKWial3TCkCIDBSerO+4=";
+          };
+      in "${src}/css-map.json";
     };
   };
 


### PR DESCRIPTION
I've taken the liberty to use `flake-utils` to simplify the `flake.nix` and use the input path definition found in <https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html?highlight=git%2Bssh#types>.

---

This change allows you to update the css map found in `spicetify-cli` with `nix flake update` without needing to update it in `spicetify-nix`.

```nix
spicetify-nix = {
  url = "github:the-argus/spicetify-nix";
  inputs.spicetify-cli.follows = "spicetify-cli";
};
spicetify-cli = {
  url = "github:spicetify/spicetify-cli";
  flake = false;
};
```