### PR TITLE
Fix missing `spicePkgs.themes.official.Default` error

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -33,7 +33,7 @@ in {
 
     theme = mkOption {
       type = types.oneOf [types.str spiceTypes.theme];
-      default = spicePkgs.themes.official.Default;
+      default = spicePkgs.themes.Default;
     };
 
     spotifyPackage = mkOption {

--- a/tests/apps.nix
+++ b/tests/apps.nix
@@ -11,7 +11,7 @@
   flatten = lib.attrsets.mapAttrsToList (_: value: value);
   apps = flatten (builtins.removeAttrs spicePkgs.apps ["override" "overrideDerivation"]);
 
-  theme = spicePkgs.official.themes.Default;
+  theme = spicePkgs.themes.Default;
 
   config-xpui = spiceLib.xpuiBuilder {
     inherit apps theme;


### PR DESCRIPTION
Fixes issue with `spicePkgs.themes.official.Default` missing.

```console
...
       … while evaluating the attribute 'default'

       at /nix/store/magp02mnp778v5vkq7nznr77vnbmsffp-source/module.nix:36:7:

           35|       type = types.oneOf [types.str spiceTypes.theme];
           36|       default = spicePkgs.themes.official.Default;
             |       ^
           37|     };

       … while evaluating the attribute 'themes.official.Default'

       at /nix/store/magp02mnp778v5vkq7nznr77vnbmsffp-source/pkgs/default.nix:16:3:

           15|   };
           16|   themes = (builtins.removeAttrs themes ["official"]) // themes.official;
             |   ^
           17|   apps = (builtins.removeAttrs apps ["official"]) // apps.official;

       error: attribute 'official' missing

       at /nix/store/magp02mnp778v5vkq7nznr77vnbmsffp-source/module.nix:36:17:

           35|       type = types.oneOf [types.str spiceTypes.theme];
           36|       default = spicePkgs.themes.official.Default;
             |                 ^
           37|     };
error: evaluation of the deployment specification failed
```