### PR TITLE
Re-add the 'text' theme

### DIFF
--- a/pkgs/themes.nix
+++ b/pkgs/themes.nix
@@ -223,7 +223,19 @@ in {
           }
         '';
       };
-
+      text = {
+        name = "text";
+        src = officialThemes;
+        patches = {
+          "xpui.js_find_8008" = ",(\\w+=)56";
+          "xpui.js_repl_8008" = ",$\{1}32";
+        };
+        injectCss = true;
+        replaceColors = true;
+        appendName = true;
+        overwriteAssets = false;
+        sidebarConfig = false;
+      };
       Dreary = {
         name = "Dreary";
         src = officialThemes;


### PR DESCRIPTION
Re-add the (accidentally) removed (#43) 'text' theme added in #37.