### PR TITLE
Fix GitHub actions

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -18,9 +18,6 @@ Modern, rounded, and minimal design, with fading effects and gradients.
 ### Flow
 Monochromatic colorschemes with subtle differences between colors, and soft vertical gradients.
 ![preview](https://raw.githubusercontent.com/spicetify/spicetify-themes/master/Flow/screenshots/ocean.png)
-### Glaze
-Simple theme which gives spotify a simpler design and a single highlight color.
-![preview](https://github.com/CharlieS1103/Glaze-theme/blob/main/screenshots/base.png)
 ### Onepunch
 Gruvbox.
 ![preview](https://github.com/spicetify/spicetify-themes/blob/master/Onepunch/screenshots/dark_home.png)

--- a/pkgs/nvfetcher.toml
+++ b/pkgs/nvfetcher.toml
@@ -68,8 +68,8 @@ src.git = "https://github.com/einzigartigerName/spicetify-history"
 fetch.git = "https://github.com/einzigartigerName/spicetify-history"
 
 [genreSrc]
-src.git = "https://github.com/Shinyhero36/Spicetify-Genre"
-fetch.git = "https://github.com/Shinyhero36/Spicetify-Genre"
+src.git = "https://github.com/jeroentvb/spicetify-genre"
+fetch.git = "https://github.com/jeroentvb/spicetify-genre"
 
 [lastfmSrc]
 src.git = "https://github.com/LucasBares/spicetify-last-fm"

--- a/pkgs/themes.nix
+++ b/pkgs/themes.nix
@@ -242,12 +242,6 @@ in {
         sidebarConfig = true;
         appendName = true;
       };
-      Glaze = {
-        name = "Glaze";
-        src = officialThemes;
-        sidebarConfig = true;
-        appendName = true;
-      };
       Turntable = {
         name = "Turntable";
         src = officialThemes;


### PR DESCRIPTION
GitHub actions have been broken for a while. This PR replaces the deleted https://github.com/Shinyhero36/Spicetify-Genre extension with the fork: https://github.com/jeroentvb/spicetify-genre and removes the deleted theme "Glaze"

Nothing has been tested beyond checking that everything builds in the included github action.